### PR TITLE
Switch to latest 'lts' stackage release for each GHC version

### DIFF
--- a/stack-ghc-8-2.yaml
+++ b/stack-ghc-8-2.yaml
@@ -1,5 +1,5 @@
 ---
-resolver: nightly-2017-12-16
+resolver: lts-11.22
 packages:
   - '.'
   - 'gen'

--- a/stack-ghc-8-4.yaml
+++ b/stack-ghc-8-4.yaml
@@ -1,5 +1,5 @@
 ---
-resolver: nightly-2018-08-06
+resolver: lts-12.26
 packages:
   - '.'
   - 'gen'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 ---
-resolver: nightly-2018-10-01
+resolver: lts-13.9
 packages:
   - '.'
   - 'gen'


### PR DESCRIPTION
Note that `ghc8.2` build fails to build the generator itself but I'm assuming it's Ok because it's not a new problem. Besides, no reason for generator itself to be portable across ghc versions.