### PR TITLE
Use a GADT for `Val a`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 * Use a GADT for `Val a` so it is properly types. This shouldn't break any
   programs that produced valid CloudFormation templates. This also allows us to
-  properly implement some more intrinsic functions, like `Not`. See:
-  - https://github.com/freckle/stratosphere/pull/120
-  - https://github.com/freckle/stratosphere/issues/80
+  properly implement some more intrinsic functions, like `Not`. See
+  https://github.com/freckle/stratosphere/pull/120
+* Added the `Fn::Not` intrinsic function. Fixes
+  https://github.com/freckle/stratosphere/issues/80
 
 ## 0.34.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.35.0
+
+* Use a GADT for `Val a` so it is properly types. This shouldn't break any
+  programs that produced valid CloudFormation templates. This also allows us to
+  properly implement some more intrinsic functions, like `Not`. See:
+  - https://github.com/freckle/stratosphere/pull/120
+  - https://github.com/freckle/stratosphere/issues/80
+
 ## 0.34.0
 
 * Don't encode `Bool`, `Int`, and `Double` values as strings in JSON. See:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 0.35.0
 
-* Use a GADT for `Val a` so it is properly types. This shouldn't break any
-  programs that produced valid CloudFormation templates. This also allows us to
+* Use a GADT for `Val a` so it is properly typed. This shouldn't break any
+  programs that produced valid CloudFormation templates, but it should increase
+  safety for templates that use intrinsic functions. This also allows us to
   properly implement some more intrinsic functions, like `Not`. See
   https://github.com/freckle/stratosphere/pull/120
 * Added the `Fn::Not` intrinsic function. Fixes

--- a/library/Stratosphere/Values.hs
+++ b/library/Stratosphere/Values.hs
@@ -29,6 +29,7 @@ data Val a where
   And :: Val Bool -> Val Bool -> Val Bool
   Equals :: (Show a, ToJSON a, Eq a, Typeable a) => Val a -> Val a -> Val Bool
   Or :: Val Bool -> Val Bool -> Val Bool
+  Not :: Val Bool -> Val Bool
   GetAtt :: Text -> Text -> Val a
   Base64 :: Val Text -> Val Text
   Join :: Text -> ValList Text -> Val Text
@@ -46,6 +47,7 @@ instance Eq a => Eq (Val a) where
   And a b == And a' b' = a == a' && b == b'
   Equals a b == Equals a' b' = eqEquals a b a' b'
   Or a b == Or a' b' = a == a' && b == b'
+  Not a == Not a' = a == a'
   GetAtt a b == GetAtt a' b' = a == a' && b == b'
   Base64 a == Base64 a' = a == a'
   FindInMap a b c == FindInMap a' b' c' = a == a' && b == b' && c == c'
@@ -69,6 +71,7 @@ instance (ToJSON a) => ToJSON (Val a) where
   toJSON (And x y) = mkFunc "Fn::And" [toJSON x, toJSON y]
   toJSON (Equals x y) = mkFunc "Fn::Equals" [toJSON x, toJSON y]
   toJSON (Or x y) = mkFunc "Fn::Or" [toJSON x, toJSON y]
+  toJSON (Not x) = mkFunc "Fn::Not" [toJSON x]
   toJSON (GetAtt x y) = mkFunc "Fn::GetAtt" [toJSON x, toJSON y]
   toJSON (Base64 v) = object [("Fn::Base64", toJSON v)]
   toJSON (Join d vs) = mkFunc "Fn::Join" [toJSON d, toJSON vs]

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stratosphere
-version: "0.34.0"
+version: "0.35.0"
 synopsis: EDSL for AWS CloudFormation
 description: EDSL for AWS CloudFormation
 category: AWS, Cloud

--- a/tests/Stratosphere/ValuesSpec.hs
+++ b/tests/Stratosphere/ValuesSpec.hs
@@ -20,22 +20,3 @@ spec = do
 
     it "ImportValue and ImportValueList produce the same JSON" $ do
       toJSON (ImportValue "MyVal" :: Val Text) `shouldBe` toJSON (ImportValueList "MyVal" :: ValList Text)
-
-    it "Functor conversions in nested Vals work" $ do
-      let
-        input :: Val Integer
-        input =
-          Select 1 $
-            ValList
-            [ Literal 1
-            , Ref "Hello"
-            , Literal 2
-            ]
-        expected =
-          Select 1 $
-            ValList
-            [ Literal 2
-            , Ref "Hello"
-            , Literal 3
-            ]
-      fmap (+1) input `shouldBe` expected


### PR DESCRIPTION
Now that we don't have `FromJSON`, we can properly use a GADT for `Val a`. Unfortunately, I'm now hitting a snag where the `Eq` and `Functor` instances can't be defined. I'll have to think about how to do this.