### PR TITLE
adding ANY to HttpMethod

### DIFF
--- a/library/Stratosphere/Types.hs
+++ b/library/Stratosphere/Types.hs
@@ -59,6 +59,7 @@ data HttpMethod
   | HEAD
   | DELETE
   | OPTIONS
+  | ANY
   deriving (Show, Read, Eq, Generic, ToJSON)
 
 data LoggingLevel


### PR DESCRIPTION
API Gateway supports the `ANY` http method. Please consider adding this as an option.