### PR TITLE
Add NodeJS10x runtime

### DIFF
--- a/library/Stratosphere/Types.hs
+++ b/library/Stratosphere/Types.hs
@@ -144,6 +144,7 @@ data Runtime
   | NodeJS43Edge
   | NodeJS610
   | NodeJS810
+  | NodeJS10x
   | Java8
   | Python27
   | Python36
@@ -159,6 +160,7 @@ instance ToJSON Runtime where
   toJSON NodeJS43Edge = String "nodejs4.3-edge"
   toJSON NodeJS610 = String "nodejs6.10"
   toJSON NodeJS810 = String "nodejs8.10"
+  toJSON NodeJS10x = String "nodejs10.x"
   toJSON Java8 = String "java8"
   toJSON Python27 = String "python2.7"
   toJSON Python36 = String "python3.6"


### PR DESCRIPTION
AWS has [support for NodeJS 10.x](https://aws.amazon.com/about-aws/whats-new/2019/05/aws_lambda_adds_support_for_node_js_v10/) since May 15, 2019.

By the way, the older runtimes are [soon deprecated](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html). But I guess they can't really be deleted (yet).