### PR TITLE
Add patch http method

### DIFF
--- a/library/Stratosphere/Types.hs
+++ b/library/Stratosphere/Types.hs
@@ -58,6 +58,7 @@ data HttpMethod
   | GET
   | HEAD
   | OPTIONS
+  | PATCH
   | POST
   | PUT
   deriving (Show, Read, Eq, Generic, ToJSON)

--- a/library/Stratosphere/Types.hs
+++ b/library/Stratosphere/Types.hs
@@ -53,13 +53,13 @@ data AuthorizationType
   deriving (Show, Read, Eq, Generic, ToJSON)
 
 data HttpMethod
-  = GET
+  = ANY
+  | DELETE
+  | GET
+  | HEAD
+  | OPTIONS
   | POST
   | PUT
-  | HEAD
-  | DELETE
-  | OPTIONS
-  | ANY
   deriving (Show, Read, Eq, Generic, ToJSON)
 
 data LoggingLevel


### PR DESCRIPTION
This PR adds the `PATCH` http method which is AFAIK supported at the places we the `HttpMethod` type is used.

I found it when trying to configure a `PATCH` method for API gateway.